### PR TITLE
Added ability to set the redirect URL in preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # osx noise
 .DS_Store
 profile
+*.crx
+*.pem

--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@ IndieWeb Reply
 
 This browser extension rewrites Twitter.com "reply" buttons to open a browser window to your own site, allowing you to post a reply from your site.
 
-Click "reply" on a tweet
+## Setup
+
+Before it can be used, you need to set the URL to redirect to in the IndieWeb Reply extension preferences. This URL is a [web action URL](http://waterpigs.co.uk/articles/web-actions/) which should provide a UI for posting a new note.
+
+You can use <code>{url}</code> in your URL (perhaps in a query parameter) and it will be replaced by the URL of the tweet you’re replying to.
+
+## Usage
+
+On twitter.com, click "Reply" on a tweet:
 
 ![A Tweet](https://github.com/aaronpk/IndieWeb-Reply-Browser-Extension/raw/master/example-tweet.png)
 

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -16,6 +16,22 @@ chrome.extension.onConnect.addListener(function(port) {
   });
 });
 
+chrome.extension.onMessage.addListener(function (request, sender, sendResponse) {
+	console.log('onMessage called with request, sender, response:');
+	console.log(request);
+	console.log(sender);
+	console.log(sendResponse);
+	
+	if (request.getLocalStorage !== undefined) {
+		console.log('Getting locally stored variable ' + request.getLocalStorage);
+		
+		var response = {};
+		response[request.getLocalStorage] = window.localStorage[request.getLocalStorage];
+		
+		sendResponse(response);
+	}
+});
+
 chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
   console.debug(request);
 });

--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -9,18 +9,13 @@ function bindTwitter() {
       $(e).unbind("click").click(function(evt){
         var tweet = $(evt.target).parents(".tweet");
         var url = "https://twitter.com/" + $(tweet).data('screen-name') + "/status/" + $(tweet).attr('data-item-id');
-
-        // TODO: THIS IS A HACK! see below.
-        var postURL = "http://pk.dev/admin/?reply_to=" + encodeURI(url);
+		
+		// Look in localstorage for IndieWebReplyPostURL
+		
+		var postURL = "http://pk.dev/admin/?reply_to=" + encodeURI(url);
         window.open(postURL);
-
-        // TODO: Need to either get the page URL from the extension preferences, or send an event to the extension
-        // where the extension can open the new window
-        // chrome.extension.sendMessage({url: url}, function(response) {
-        //   console.log(response);
-        // });
-
-        return false;
+		
+		return false;
       });
     });
 }

--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -10,18 +10,17 @@ function bindTwitter() {
         var tweet = $(evt.target).parents(".tweet");
         var url = "https://twitter.com/" + $(tweet).data('screen-name') + "/status/" + $(tweet).attr('data-item-id');
 		
-		// Look in localstorage for IndieWebReplyPostURL
-		if (window.localStorage.IndieWebReplyPostURL === undefined) {
-			alert('You must set a Reply Post URL in Chrome options in order to use IndieWeb Reply');
-			return false;
-		}
-		
 		var replace = {
 			url: encodeURI(url)
 		};
 		
 		chrome.extension.sendMessage({'getLocalStorage': 'IndieWebReplyPostURL'}, function (response) {
 			var postURL = response.IndieWebReplyPostURL;
+			
+			if (postURL === undefined) {
+				alert('You must set a Reply Post URL in Chrome options in order to use IndieWeb Reply');
+				return false;
+			}
 			
 			// Replace template vars
 			for (var template in replace) {

--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -11,9 +11,25 @@ function bindTwitter() {
         var url = "https://twitter.com/" + $(tweet).data('screen-name') + "/status/" + $(tweet).attr('data-item-id');
 		
 		// Look in localstorage for IndieWebReplyPostURL
+		if (window.localStorage.IndieWebReplyPostURL === undefined) {
+			alert('You must set a Reply Post URL in Chrome options in order to use IndieWeb Reply');
+			return false;
+		}
 		
-		var postURL = "http://pk.dev/admin/?reply_to=" + encodeURI(url);
-        window.open(postURL);
+		var replace = {
+			url: encodeURI(url)
+		};
+		
+		chrome.extension.sendMessage({'getLocalStorage': 'IndieWebReplyPostURL'}, function (response) {
+			var postURL = response.IndieWebReplyPostURL;
+			
+			// Replace template vars
+			for (var template in replace) {
+				postURL = postURL.split('{' + template + '}').join(replace[template]);
+			}
+			
+			window.open(postURL);
+		});
 		
 		return false;
       });

--- a/chrome/content_script.js
+++ b/chrome/content_script.js
@@ -24,6 +24,8 @@ function bindTwitter() {
 			
 			// Replace template vars
 			for (var template in replace) {
+				if (replace[template] == undefined)
+					continue;
 				postURL = postURL.split('{' + template + '}').join(replace[template]);
 			}
 			

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!doctype>
 <html>
 <head>
   <title>Options for the IndieWeb Reply Extension</title>
@@ -8,16 +8,24 @@
    * LICENSE file.
   -->
   <style>
-    #providerSelection {
-      font-family: Helvetica, Arial, sans-serif;
-      font-size: 10pt;
+    body {
+    	font-family: "Georgia", serif;
+    	font-size: 18px;
+    }
+    
+    input[type=url] {
+    	font-size: 18px;
+    	width: 50em;
+    	max-width: 100%;
     }
   </style>
   <script src="options.js"></script>
 </head>
 <body>
+	<h1>Indieweb Reply Preferences</h1>
+	
 	<div id="providerSelection">
-		<p>Enter the URL of your “new note” UI:</p>
+		<p>Enter the URL of your new note UI:</p>
 		
 		<label>URL: <input id="postURL" name="postURL" type="url" /></label>
 		

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -16,24 +16,17 @@
   <script src="options.js"></script>
 </head>
 <body>
-  <table border="0">
-    <tr>
-      <td rowspan="2" valign="top" align="center" width="80">
-        <img src="mail_128x128.png" width="64" height="64" />
-      </td>
-      <td height="22"></td>
-    </tr>
-    <tr>
-      <td valign="center">
-        <div id="providerSelection">
-        <strong>Enter your posting URL:</strong>
-        <br /><br />
-        <label>
-          <input id="postURL" name="postURL" type="text" />
-        </label>
-        </div>
-      </td>
-    </tr>
-  </table>
+	<div id="providerSelection">
+		<p>Enter the URL of your “new note” UI:</p>
+		
+		<label>URL: <input id="postURL" name="postURL" type="url" /></label>
+		
+		<p>The following expressions will be expanded:</p>
+		
+		<dl>
+			<dt><code>{url}</code>
+			<dd>Expands to the (urlencoded) URL of the current page
+		</dl>
+	</div>
 </body>
 </html>

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -9,7 +9,7 @@ function saveURL(evt) {
     alert('Local storage is required for changing providers');
     return;
   }
-  window.localStorage.postURL = evt.target.value;
+  window.localStorage.IndieWebReplyPostURL = evt.target.value;
 }
 
 function main() {

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -18,7 +18,7 @@ function main() {
     return;
   }
 
-  document.getElementById('postURL').value = window.localStorage.postURL;
+  document.getElementById('postURL').value = window.localStorage.IndieWebReplyPostURL;
 }
 
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
Added this vital feature, and improved the styling on the options page.

Also added the start of something potentially rather powerful: in the URL, you can put placeholders (currently `{url}`) which will be replaced with the URL-encoded URL of the tweet at click-time. If we included @benward’s JS microformats parser we could potentially parse some other data out too.
